### PR TITLE
Packagename was incorrect when name contained multiple full stops

### DIFF
--- a/stacko.go
+++ b/stacko.go
@@ -2,7 +2,6 @@
 package stacko
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"

--- a/stacko.go
+++ b/stacko.go
@@ -2,6 +2,7 @@
 package stacko
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -111,8 +112,8 @@ func FunctionInfo(pc uintptr) (string, string) {
 	}
 
 	info := name[slash:]
-	dot := strings.LastIndex(info, ".")
-
+	dot := strings.Index(info, ".")
+	fmt.Printf("Name: %s info: %s, %s %s\n", name, info, info[:dot], info[dot+1:])
 	return info[:dot], info[dot+1:]
 }
 

--- a/stacko.go
+++ b/stacko.go
@@ -113,7 +113,6 @@ func FunctionInfo(pc uintptr) (string, string) {
 
 	info := name[slash:]
 	dot := strings.Index(info, ".")
-	fmt.Printf("Name: %s info: %s, %s %s\n", name, info, info[:dot], info[dot+1:])
 	return info[:dot], info[dot+1:]
 }
 

--- a/stacko_test.go
+++ b/stacko_test.go
@@ -10,11 +10,60 @@ import (
 // of the stacktrace is correct, this should gives us a stacktrace of 4 frames.
 func TestNewStacktrace(t *testing.T) {
 	stacktrace, err := NewStacktrace(0)
+	var expected string
 	if err != nil {
 		t.Error(err)
 	}
 
 	if len(stacktrace) != 4 {
 		t.Error("Stacktrace should be 4 frames.")
+	}
+
+	expected = "stacko"
+	if stacktrace[0].PackageName != expected {
+		t.Errorf("Expected stacktrace[0].PackageName == '%s'. Was: '%s'",
+			expected, stacktrace[0].PackageName)
+	}
+
+	expected = "NewStacktrace"
+	if stacktrace[0].FunctionName != expected {
+		t.Errorf("Expected stacktrace[0].FunctionName == '%s'. Was: '%s'",
+			expected, stacktrace[0].FunctionName)
+	}
+
+	expected = "stacko"
+	if stacktrace[1].PackageName != expected {
+		t.Errorf("Expected stacktrace[1].PackageName == '%s'. Was: '%s'",
+			expected, stacktrace[1].PackageName)
+	}
+
+	expected = "TestNewStacktrace"
+	if stacktrace[1].FunctionName != expected {
+		t.Errorf("Expected stacktrace[1].FunctionName == '%s'. Was: '%s'",
+			expected, stacktrace[1].FunctionName)
+	}
+
+	expected = "testing"
+	if stacktrace[2].PackageName != expected {
+		t.Errorf("Expected stacktrace[2].PackageName == '%s'. Was: '%s'",
+			expected, stacktrace[2].PackageName)
+	}
+
+	expected = "tRunner"
+	if stacktrace[2].FunctionName != expected {
+		t.Errorf("Expected stacktrace[2].FunctionName == '%s'. Was: '%s'",
+			expected, stacktrace[2].FunctionName)
+	}
+
+	expected = "runtime"
+	if stacktrace[3].PackageName != expected {
+		t.Errorf("Expected stacktrace[3].PackageName == '%s'. Was: '%s'",
+			expected, stacktrace[3].PackageName)
+	}
+
+	expected = "goexit"
+	if stacktrace[3].FunctionName != expected {
+		t.Errorf("Expected stacktrace[3].FunctionName == '%s'. Was: '%s'",
+			expected, stacktrace[3].FunctionName)
 	}
 }


### PR DESCRIPTION
Also made the test a little stricter.